### PR TITLE
Fix static routing to ensure `index.html` is specified

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,6 +1,7 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   output: 'export',
+  trailingSlash: true,
   webpack: (config, options) => {
     config.module.rules.push({
       test: /\.vert/,


### PR DESCRIPTION
## What

Ensure `index.html` is used for pages.

> By default Next.js will redirect urls with trailing slashes to their counterpart without a trailing slash. For example /about/ will redirect to /about. You can configure this behavior to act the opposite way, where urls without trailing slashes are redirected to their counterparts with trailing slashes.

https://nextjs.org/docs/app/api-reference/next-config-js/trailingSlash